### PR TITLE
shaders: texture2D -> texture

### DIFF
--- a/src/renderer/shaders/deferred_directional_light_fs.glsl
+++ b/src/renderer/shaders/deferred_directional_light_fs.glsl
@@ -15,8 +15,8 @@ out vec4 FragColor;
 
 void main()
 {
-    vec3 fragmentNormal = normalize(texture2D(normalTexture, texCoord).xyz * 2.0 - 1.0);
-    vec3 fragmentPosition = S_UnProject(vec3(texCoord, texture2D(depthTexture, texCoord).r), invViewProj);
+    vec3 fragmentNormal = normalize(texture(normalTexture, texCoord).xyz * 2.0 - 1.0);
+    vec3 fragmentPosition = S_UnProject(vec3(texCoord, texture(depthTexture, texCoord).r), invViewProj);
     const float specularPower = 80.0;
 
     vec3 h = normalize(lightDirection + (cameraPosition - fragmentPosition));
@@ -24,7 +24,7 @@ void main()
 
     float lambertian = max(dot(fragmentNormal, lightDirection), 0);
 
-    FragColor = texture2D(colorTexture, texCoord);
+    FragColor = texture(colorTexture, texCoord);
     FragColor.xyz += 0.4 * specular;
     FragColor *= lambertian * lightColor;
 }

--- a/src/renderer/shaders/deferred_point_light_fs.glsl
+++ b/src/renderer/shaders/deferred_point_light_fs.glsl
@@ -21,8 +21,8 @@ void main()
     TBlinnPhongContext ctx;
     ctx.lightPosition = lightPos;
     ctx.lightRadius = lightRadius;
-    ctx.fragmentNormal = normalize(texture2D(normalTexture, texCoord).xyz * 2.0 - 1.0);
-    ctx.fragmentPosition = S_UnProject(vec3(texCoord, texture2D(depthTexture, texCoord).r), invViewProj);
+    ctx.fragmentNormal = normalize(texture(normalTexture, texCoord).xyz * 2.0 - 1.0);
+    ctx.fragmentPosition = S_UnProject(vec3(texCoord, texture(depthTexture, texCoord).r), invViewProj);
     ctx.cameraPosition = cameraPosition;
     ctx.specularPower = 80.0;
     TBlinnPhong lighting = S_BlinnPhong(ctx);
@@ -69,7 +69,7 @@ void main()
         }
     }
 
-    FragColor = texture2D(colorTexture, texCoord);
+    FragColor = texture(colorTexture, texCoord);
     FragColor.xyz += 0.4 * lighting.specular;
     FragColor *= lighting.attenuation * shadow * lightColor;
 }

--- a/src/renderer/shaders/deferred_spot_light_fs.glsl
+++ b/src/renderer/shaders/deferred_spot_light_fs.glsl
@@ -26,8 +26,8 @@ void main()
     TBlinnPhongContext ctx;
     ctx.lightPosition = lightPos;
     ctx.lightRadius = lightRadius;
-    ctx.fragmentNormal = normalize(texture2D(normalTexture, texCoord).xyz * 2.0 - 1.0);
-    ctx.fragmentPosition = S_UnProject(vec3(texCoord, texture2D(depthTexture, texCoord).r), invViewProj);
+    ctx.fragmentNormal = normalize(texture(normalTexture, texCoord).xyz * 2.0 - 1.0);
+    ctx.fragmentPosition = S_UnProject(vec3(texCoord, texture(depthTexture, texCoord).r), invViewProj);
     ctx.cameraPosition = cameraPosition;
     ctx.specularPower = 80.0;
     TBlinnPhong lighting = S_BlinnPhong(ctx);
@@ -65,7 +65,7 @@ void main()
         }
     }
 
-    FragColor = texture2D(colorTexture, texCoord);
+    FragColor = texture(colorTexture, texCoord);
     FragColor.xyz += 0.4 * lighting.specular;
     FragColor *= coneFactor * shadow * lighting.attenuation * lightColor;
 }

--- a/src/renderer/shaders/gbuffer_fs.glsl
+++ b/src/renderer/shaders/gbuffer_fs.glsl
@@ -18,12 +18,12 @@ in vec2 secondTexCoord;
 
 void main()
 {
-    outColor = diffuseColor * texture2D(diffuseTexture, texCoord);
+    outColor = diffuseColor * texture(diffuseTexture, texCoord);
     if (outColor.a < 0.5) discard;
     outColor.a = 1;
-    vec4 n = normalize(texture2D(normalTexture, texCoord) * 2.0 - 1.0);
+    vec4 n = normalize(texture(normalTexture, texCoord) * 2.0 - 1.0);
     mat3 tangentSpace = mat3(tangent, binormal, normal);
     outNormal.xyz = normalize(tangentSpace * n.xyz) * 0.5 + 0.5;
-    outNormal.w = texture2D(specularTexture, texCoord).r;
-    outAmbient = vec4(texture2D(lightmapTexture, secondTexCoord).rgb, 1.0);
+    outNormal.w = texture(specularTexture, texCoord).r;
+    outAmbient = vec4(texture(lightmapTexture, secondTexCoord).rgb, 1.0);
 }


### PR DESCRIPTION
Fixes compilation on macos 10.15.6

Error without the patch:
`Failed to compile GBufferShader_FragmentShader shader: ERROR: 0:176: Invalid call of undeclared identifier 'texture2D'`

texture2D() is deprecated in favor for texture() as of at least opengl 3.3