### PR TITLE
Allow key input in examples on macOS (#32)

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -311,7 +311,7 @@ fn main() {
                             engine.user_interface.send_message(WidgetMessage::visibility(interface.progress_text,MessageDirection::ToWidget, false));
                         }
 
-                        // Report progress in UI. 
+                        // Report progress in UI.
                         engine.user_interface.send_message(ProgressBarMessage::progress(interface.progress_bar, MessageDirection::ToWidget,load_context.progress));
                         engine.user_interface.send_message(
                             TextMessage::text(interface.progress_text,MessageDirection::ToWidget,
@@ -386,6 +386,16 @@ fn main() {
                         engine.user_interface.send_message(WidgetMessage::width(interface.root, MessageDirection::ToWidget,size.width));
                         engine.user_interface.send_message(WidgetMessage::height(interface.root, MessageDirection::ToWidget,size.height));
                     }
+                    WindowEvent::KeyboardInput { input, ..} => {
+                        // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
+                        if let Some(key_code) = input.virtual_keycode {
+                            match key_code {
+                            VirtualKeyCode::A => input_controller.rotate_left = input.state == ElementState::Pressed,
+                            VirtualKeyCode::D => input_controller.rotate_right = input.state == ElementState::Pressed,
+                            _ => ()
+                        }
+                        }
+                    }
                     _ => ()
                 }
 
@@ -397,15 +407,7 @@ fn main() {
                 }
             }
             Event::DeviceEvent { event, .. } => {
-                if let DeviceEvent::Key(key) = event {
-                    if let Some(key_code) = key.virtual_keycode {
-                        match key_code {
-                            VirtualKeyCode::A => input_controller.rotate_left = key.state == ElementState::Pressed,
-                            VirtualKeyCode::D => input_controller.rotate_right = key.state == ElementState::Pressed,
-                            _ => ()
-                        }
-                    }
-                }
+                // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
             }
             _ => *control_flow = ControlFlow::Poll,
         }

--- a/examples/lightmap.rs
+++ b/examples/lightmap.rs
@@ -217,6 +217,22 @@ fn main() {
                         // directly when window size has changed.
                         engine.renderer.set_frame_size(size.into());
                     }
+                    WindowEvent::KeyboardInput { input, .. } => {
+                        // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
+                        if let Some(key_code) = input.virtual_keycode {
+                            match key_code {
+                                VirtualKeyCode::A => {
+                                    input_controller.rotate_left =
+                                        input.state == ElementState::Pressed
+                                }
+                                VirtualKeyCode::D => {
+                                    input_controller.rotate_right =
+                                        input.state == ElementState::Pressed
+                                }
+                                _ => (),
+                            }
+                        }
+                    }
                     _ => (),
                 }
 
@@ -228,19 +244,7 @@ fn main() {
                 }
             }
             Event::DeviceEvent { event, .. } => {
-                if let DeviceEvent::Key(key) = event {
-                    if let Some(key_code) = key.virtual_keycode {
-                        match key_code {
-                            VirtualKeyCode::A => {
-                                input_controller.rotate_left = key.state == ElementState::Pressed
-                            }
-                            VirtualKeyCode::D => {
-                                input_controller.rotate_right = key.state == ElementState::Pressed
-                            }
-                            _ => (),
-                        }
-                    }
-                }
+                // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
             }
             _ => *control_flow = ControlFlow::Poll,
         }

--- a/examples/scene.rs
+++ b/examples/scene.rs
@@ -201,6 +201,22 @@ fn main() {
                         // directly when window size has changed.
                         engine.renderer.set_frame_size(size.into());
                     }
+                    WindowEvent::KeyboardInput { input, .. } => {
+                        // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
+                        if let Some(key_code) = input.virtual_keycode {
+                            match key_code {
+                                VirtualKeyCode::A => {
+                                    input_controller.rotate_left =
+                                        input.state == ElementState::Pressed
+                                }
+                                VirtualKeyCode::D => {
+                                    input_controller.rotate_right =
+                                        input.state == ElementState::Pressed
+                                }
+                                _ => (),
+                            }
+                        }
+                    }
                     _ => (),
                 }
 
@@ -212,19 +228,7 @@ fn main() {
                 }
             }
             Event::DeviceEvent { event, .. } => {
-                if let DeviceEvent::Key(key) = event {
-                    if let Some(key_code) = key.virtual_keycode {
-                        match key_code {
-                            VirtualKeyCode::A => {
-                                input_controller.rotate_left = key.state == ElementState::Pressed
-                            }
-                            VirtualKeyCode::D => {
-                                input_controller.rotate_right = key.state == ElementState::Pressed
-                            }
-                            _ => (),
-                        }
-                    }
-                }
+                // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
             }
             _ => *control_flow = ControlFlow::Poll,
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -248,6 +248,22 @@ fn main() {
                         // directly when window size has changed.
                         engine.renderer.set_frame_size(size.into());
                     }
+                    WindowEvent::KeyboardInput { input, .. } => {
+                        // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
+                        if let Some(key_code) = input.virtual_keycode {
+                            match key_code {
+                                VirtualKeyCode::A => {
+                                    input_controller.rotate_left =
+                                        input.state == ElementState::Pressed
+                                }
+                                VirtualKeyCode::D => {
+                                    input_controller.rotate_right =
+                                        input.state == ElementState::Pressed
+                                }
+                                _ => (),
+                            }
+                        }
+                    }
                     _ => (),
                 }
 
@@ -259,19 +275,7 @@ fn main() {
                 }
             }
             Event::DeviceEvent { event, .. } => {
-                if let DeviceEvent::Key(key) = event {
-                    if let Some(key_code) = key.virtual_keycode {
-                        match key_code {
-                            VirtualKeyCode::A => {
-                                input_controller.rotate_left = key.state == ElementState::Pressed
-                            }
-                            VirtualKeyCode::D => {
-                                input_controller.rotate_right = key.state == ElementState::Pressed
-                            }
-                            _ => (),
-                        }
-                    }
-                }
+                // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
             }
             _ => *control_flow = ControlFlow::Poll,
         }

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -513,6 +513,15 @@ fn main() {
                         // directly when window size has changed.
                         engine.renderer.set_frame_size(dbg!(size.into()));
                     }
+                    WindowEvent::KeyboardInput { input, .. } => {
+                        if let Some(key_code) = input.virtual_keycode {
+                            if input.state == ElementState::Pressed
+                                && key_code == VirtualKeyCode::Escape
+                            {
+                                *control_flow = ControlFlow::Exit;
+                            }
+                        }
+                    }
                     _ => (),
                 }
 
@@ -524,14 +533,7 @@ fn main() {
                 }
             }
             Event::DeviceEvent { event, .. } => {
-                if let DeviceEvent::Key(key) = event {
-                    if let Some(key_code) = key.virtual_keycode {
-                        if key.state == ElementState::Pressed && key_code == VirtualKeyCode::Escape
-                        {
-                            *control_flow = ControlFlow::Exit;
-                        }
-                    }
-                }
+                // Handle key input events via `WindowEvent`, not via `DeviceEvent` (#32)
             }
             _ => *control_flow = ControlFlow::Poll,
         }


### PR DESCRIPTION
Fixes #32

* handle key inputs via `WindowEvent`s
* (keep handling mouse inputs via `DeviceEvent`s)

Not tested on Windows/Linux.

Off topic: I'm not familar with Git/GitHub, but feel free to squash these commits if you like.