### PR TITLE
Add Specular Textures

### DIFF
--- a/rg3d-core/src/math/ray.rs
+++ b/rg3d-core/src/math/ray.rs
@@ -406,7 +406,7 @@ impl Ray {
 #[cfg(test)]
 mod test {
     use crate::math::ray::Ray;
-    use crate::math::vec3::Vector3;
+    use crate::math::Vector3;
 
     #[test]
     fn intersection() {

--- a/src/renderer/deferred_light_renderer.rs
+++ b/src/renderer/deferred_light_renderer.rs
@@ -362,19 +362,6 @@ impl DeferredLightRenderer {
         let view_projection = camera.view_projection_matrix();
         let inv_view_projection = view_projection.try_inverse().unwrap_or_default();
 
-        /*
-        let vm = Matrix3::new(
-            camera.view_matrix().m11,
-            camera.view_matrix().m12,
-            camera.view_matrix().m13,
-            camera.view_matrix().m21,
-            camera.view_matrix().m22,
-            camera.view_matrix().m23,
-            camera.view_matrix().m31,
-            camera.view_matrix().m32,
-            camera.view_matrix().m33,
-        );*/
-
         // Fill SSAO map.
         if settings.use_ssao {
             statistics += self.ssao_renderer.render(

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -329,6 +329,9 @@ pub struct Renderer {
     /// Dummy one pixel texture with (0, 1, 0) vector is used as stub when rendering
     /// something without normal map.
     normal_dummy: Rc<RefCell<GpuTexture>>,
+    /// Dummy one pixel texture used as stub when rendering something without a
+    /// specular texture
+    specular_dummy: Rc<RefCell<GpuTexture>>,
     ui_renderer: UiRenderer,
     statistics: Statistics,
     quad: SurfaceSharedData,
@@ -560,6 +563,18 @@ impl Renderer {
                 1,
                 Some(&[128, 128, 255, 255]),
             )?)),
+            specular_dummy: Rc::new(RefCell::new(GpuTexture::new(
+                &mut state,
+                GpuTextureKind::Rectangle {
+                    width: 1,
+                    height: 1,
+                },
+                PixelKind::RGBA8,
+                MinificationFilter::Linear,
+                MagnificationFilter::Linear,
+                1,
+                Some(&[32, 32, 32, 32]),
+            )?)),
             quad: SurfaceSharedData::make_unit_xy_quad(),
             ui_renderer: UiRenderer::new(&mut state)?,
             particle_system_renderer: ParticleSystemRenderer::new(&mut state)?,
@@ -744,6 +759,7 @@ impl Renderer {
                     camera,
                     white_dummy: self.white_dummy.clone(),
                     normal_dummy: self.normal_dummy.clone(),
+                    specular_dummy: self.specular_dummy.clone(),
                     texture_cache: &mut self.texture_cache,
                     geom_cache: &mut self.geometry_cache,
                 });

--- a/src/renderer/shaders/deferred_directional_light_fs.glsl
+++ b/src/renderer/shaders/deferred_directional_light_fs.glsl
@@ -17,7 +17,7 @@ void main()
 {
     vec3 fragmentNormal = normalize(texture(normalTexture, texCoord).xyz * 2.0 - 1.0);
     vec3 fragmentPosition = S_UnProject(vec3(texCoord, texture(depthTexture, texCoord).r), invViewProj);
-    const float specularPower = 80.0;
+    float specularPower = 255.0 * texture(normalTexture, texCoord).w;
 
     vec3 h = normalize(lightDirection + (cameraPosition - fragmentPosition));
     float specular = pow(clamp(dot(fragmentNormal, h), 0.0, 1.0), specularPower);

--- a/src/renderer/shaders/deferred_point_light_fs.glsl
+++ b/src/renderer/shaders/deferred_point_light_fs.glsl
@@ -25,7 +25,7 @@ void main()
     ctx.fragmentNormal = normalize(texture(normalTexture, texCoord).xyz * 2.0 - 1.0);
     ctx.fragmentPosition = S_UnProject(vec3(texCoord, texture(depthTexture, texCoord).r), invViewProj);
     ctx.cameraPosition = cameraPosition;
-    ctx.specularPower = 80.0;
+    ctx.specularPower = 255.0 * texture(normalTexture, texCoord).w;
     TBlinnPhong lighting = S_BlinnPhong(ctx);
 
     float shadow = 1.0;

--- a/src/renderer/shaders/deferred_spot_light_fs.glsl
+++ b/src/renderer/shaders/deferred_spot_light_fs.glsl
@@ -30,7 +30,7 @@ void main()
     ctx.fragmentNormal = normalize(texture(normalTexture, texCoord).xyz * 2.0 - 1.0);
     ctx.fragmentPosition = S_UnProject(vec3(texCoord, texture(depthTexture, texCoord).r), invViewProj);
     ctx.cameraPosition = cameraPosition;
-    ctx.specularPower = 80.0;
+    ctx.specularPower = 255.0 * texture(normalTexture, texCoord).w;
     TBlinnPhong lighting = S_BlinnPhong(ctx);
 
     float spotAngleCos = dot(lightDirection, lighting.direction);

--- a/src/renderer/surface.rs
+++ b/src/renderer/surface.rs
@@ -1,8 +1,8 @@
-//! For efficient rendering each mesh is split into sets of triangles that uses same texture,
+//! For efficient rendering each mesh is split into sets of triangles that use the same texture,
 //! such sets are called surfaces.
 //!
-//! Surfaces can use same data source across many instances, this is memory optimization for
-//! to be able to re-use data when you need to draw same mesh in many places.
+//! Surfaces can use the same data source across many instances, this is a memory optimization for
+//! being able to re-use data when you need to draw the same mesh in many places.
 
 use crate::core::algebra::{Matrix4, Vector2, Vector3, Vector4};
 use crate::{
@@ -994,6 +994,7 @@ pub struct Surface {
     diffuse_texture: Option<Texture>,
     normal_texture: Option<Texture>,
     lightmap_texture: Option<Texture>,
+    specular_texture: Option<Texture>,
     /// Temporal array for FBX conversion needs, it holds skinning data (weight + bone handle)
     /// and will be used to fill actual bone indices and weight in vertices that will be
     /// sent to GPU. The idea is very simple: GPU needs to know only indices of matrices of
@@ -1018,6 +1019,7 @@ impl Clone for Surface {
             data: self.data.clone(),
             diffuse_texture: self.diffuse_texture.clone(),
             normal_texture: self.normal_texture.clone(),
+            specular_texture: self.specular_texture.clone(),
             bones: self.bones.clone(),
             vertex_weights: Vec::new(), // Intentionally not copied.
             color: self.color,
@@ -1034,6 +1036,7 @@ impl Surface {
             data: Some(data),
             diffuse_texture: None,
             normal_texture: None,
+            specular_texture: None,
             bones: Vec::new(),
             vertex_weights: Vec::new(),
             color: Color::WHITE,
@@ -1069,6 +1072,18 @@ impl Surface {
     #[inline]
     pub fn normal_texture(&self) -> Option<Texture> {
         self.normal_texture.clone()
+    }
+
+    /// Sets new specular texture.
+    #[inline]
+    pub fn set_specular_texture(&mut self, tex: Option<Texture>) {
+        self.specular_texture = tex;
+    }
+
+    /// Returns current specular texture.
+    #[inline]
+    pub fn specular_texture(&self) -> Option<Texture> {
+        self.specular_texture.clone()
     }
 
     /// Sets new lightmap texture.
@@ -1127,6 +1142,7 @@ pub struct SurfaceBuilder {
     diffuse_texture: Option<Texture>,
     normal_texture: Option<Texture>,
     lightmap_texture: Option<Texture>,
+    specular_texture: Option<Texture>,
     bones: Vec<Handle<Node>>,
     color: Color,
 }
@@ -1139,6 +1155,7 @@ impl SurfaceBuilder {
             diffuse_texture: None,
             normal_texture: None,
             lightmap_texture: None,
+            specular_texture: None,
             bones: Default::default(),
             color: Color::WHITE,
         }
@@ -1162,6 +1179,12 @@ impl SurfaceBuilder {
         self
     }
 
+    /// Sets desired specular texture.
+    pub fn with_specular_texture(mut self, tex: Texture) -> Self {
+        self.specular_texture = Some(tex);
+        self
+    }
+
     /// Sets desired color of surface.
     pub fn with_color(mut self, color: Color) -> Self {
         self.color = color;
@@ -1181,6 +1204,7 @@ impl SurfaceBuilder {
             diffuse_texture: self.diffuse_texture,
             normal_texture: self.normal_texture,
             lightmap_texture: self.lightmap_texture,
+            specular_texture: self.specular_texture,
             vertex_weights: Default::default(),
             bones: self.bones,
             color: self.color,

--- a/src/resource/fbx/mod.rs
+++ b/src/resource/fbx/mod.rs
@@ -231,11 +231,12 @@ fn create_surfaces(
                 let texture = fbx_scene.get(*texture_handle).as_texture()?;
                 let path = texture.get_file_path();
                 if let Some(filename) = path.file_name() {
-                    let diffuse_path = resource_manager.state().textures_path().join(&filename);
-                    let texture = resource_manager.request_texture(diffuse_path.as_path());
+                    let texture_path = resource_manager.state().textures_path().join(&filename);
+                    let texture = resource_manager.request_texture(texture_path.as_path());
                     match name.as_str() {
                         "AmbientColor" => (), // TODO: Add ambient occlusion (AO) map support.
                         "DiffuseColor" => surface.set_diffuse_texture(Some(texture)),
+                        "SpecularFactor" => surface.set_specular_texture(Some(texture)),
                         // No idea why it can be different for normal maps.
                         "Bump" | "NormalMap" => surface.set_normal_texture(Some(texture)),
                         _ => (),


### PR DESCRIPTION
I added specular texture rendering and the fbx loader loads the `SpecularFactor` into a texture.

This pull request might alter the appearance of existing projects. Originally the specular power/exponent/factor was hardcoded to `80`, now it is anywhere between `0` and `255` and by default probably `255`, because I use the white_dummy texture, when no specular texture exists. I'm not sure if this is a reasonable default for this.