### PR TITLE
updated sysinfo to 0.16.3

### DIFF
--- a/rg3d-ui/Cargo.toml
+++ b/rg3d-ui/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 rg3d-core = { path = "../rg3d-core", version = "0.11.0" }
 lazy_static = "1.4.0"
-sysinfo = "0.15.1"
+sysinfo = "0.16.3"
 fontdue = "0.4.0"
 
 [features]


### PR DESCRIPTION
the old version didn't work on apple m1 cpus