### PR TITLE
fix `cargo doc` warnings

### DIFF
--- a/rg3d-core/src/math/plane.rs
+++ b/rg3d-core/src/math/plane.rs
@@ -58,7 +58,7 @@ impl Plane {
         self.dot(point).abs()
     }
 
-    /// http://geomalgorithms.com/a05-_intersect-1.html
+    /// <http://geomalgorithms.com/a05-_intersect-1.html>
     pub fn intersection_point(&self, b: &Plane, c: &Plane) -> Vector3<f32> {
         let f = -1.0 / self.normal.dot(&b.normal.cross(&c.normal));
 

--- a/rg3d-core/src/math/ray.rs
+++ b/rg3d-core/src/math/ray.rs
@@ -262,7 +262,7 @@ impl Ray {
 
     /// Generic ray-cylinder intersection test.
     ///
-    /// https://mrl.nyu.edu/~dzorin/rend05/lecture2.pdf
+    /// <https://mrl.nyu.edu/~dzorin/rend05/lecture2.pdf>
     ///
     ///  Infinite cylinder oriented along line pa + va * t:
     ///      sqr_len(q - pa - dot(va, q - pa) * va) - r ^ 2 = 0

--- a/rg3d-core/src/pool.rs
+++ b/rg3d-core/src/pool.rs
@@ -527,7 +527,7 @@ impl<T> Pool<T> {
     ///
     /// # Panics
     ///
-    /// See [`borrow_mut`].
+    /// See [`borrow_mut`](Self::borrow_mut).
     ///
     /// # Example
     ///
@@ -557,7 +557,7 @@ impl<T> Pool<T> {
     ///
     /// # Panics
     ///
-    /// See [`borrow_mut`].
+    /// See [`borrow_mut`](Self::borrow_mut).
     ///
     /// # Example
     ///
@@ -598,7 +598,7 @@ impl<T> Pool<T> {
     ///
     /// # Panics
     ///
-    /// See [`borrow_mut`].
+    /// See [`borrow_mut`](Self::borrow_mut).
     ///
     /// # Example
     ///
@@ -789,7 +789,7 @@ impl<T> Pool<T> {
     ///
     /// Use this method cautiously if objects in pool have cross "references" (handles)
     /// to each other. This method will make all produced handles invalid and any further
-    /// calls for [`borrow`] or [`borrow_mut`] will raise panic.
+    /// calls for [`borrow`](Self::borrow) or [`borrow_mut`](Self::borrow_mut) will raise panic.
     ///
     #[inline]
     pub fn clear(&mut self) {

--- a/rg3d-sound/src/device/dummy.rs
+++ b/rg3d-sound/src/device/dummy.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use crate::{
     device::{Device, FeedCallback, MixContext, NativeSample},
     error::SoundError,

--- a/rg3d-sound/src/dsp/filters.rs
+++ b/rg3d-sound/src/dsp/filters.rs
@@ -10,7 +10,7 @@ use crate::dsp::DelayLine;
 use rg3d_core::visitor::{Visit, VisitResult, Visitor};
 
 /// One-pole Filter.
-/// For details see - https://www.earlevel.com/main/2012/12/15/a-one-pole-filter/
+/// For details see - <https://www.earlevel.com/main/2012/12/15/a-one-pole-filter/>
 #[derive(Debug, Clone)]
 pub struct OnePole {
     a0: f32,
@@ -76,7 +76,7 @@ impl Visit for OnePole {
 }
 
 /// Lowpass-Feedback Comb Filter
-/// For details see - https://ccrma.stanford.edu/~jos/pasp/Lowpass_Feedback_Comb_Filter.html
+/// For details see - <https://ccrma.stanford.edu/~jos/pasp/Lowpass_Feedback_Comb_Filter.html>
 #[derive(Debug, Clone)]
 pub struct LpfComb {
     low_pass: OnePole,
@@ -144,8 +144,8 @@ impl Visit for LpfComb {
     }
 }
 
-/// Allpass Filter - https://ccrma.stanford.edu/~jos/pasp/Allpass_Filters.html
-/// For details see - https://ccrma.stanford.edu/~jos/pasp/Allpass_Two_Combs.html
+/// Allpass Filter - <https://ccrma.stanford.edu/~jos/pasp/Allpass_Filters.html>
+/// For details see - <https://ccrma.stanford.edu/~jos/pasp/Allpass_Two_Combs.html>
 #[derive(Debug, Clone)]
 pub struct AllPass {
     delay_line: DelayLine,
@@ -203,7 +203,7 @@ impl Visit for AllPass {
 }
 
 /// Exact kind of biquad filter - it defines coefficients of the filter.
-/// More info here: https://shepazu.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html
+/// More info here: <https://shepazu.github.io/Audio-EQ-Cookbook/audio-eq-cookbook.html>
 pub enum BiquadKind {
     /// Reduces amplitude of frequencies higher F_center.
     LowPass,
@@ -227,7 +227,7 @@ pub enum BiquadKind {
 }
 
 /// Generic second order digital filter.
-/// More info here: https://ccrma.stanford.edu/~jos/filters/BiQuad_Section.html
+/// More info here: <https://ccrma.stanford.edu/~jos/filters/BiQuad_Section.html>
 #[derive(Clone, Debug)]
 pub struct Biquad {
     b0: f32,

--- a/rg3d-sound/src/dsp/mod.rs
+++ b/rg3d-sound/src/dsp/mod.rs
@@ -12,7 +12,7 @@ use rg3d_core::visitor::{Visit, VisitResult, Visitor};
 
 pub mod filters;
 
-/// See more info here https://ccrma.stanford.edu/~jos/pasp/Delay_Lines.html
+/// See more info here <https://ccrma.stanford.edu/~jos/pasp/Delay_Lines.html>
 #[derive(Debug, Clone)]
 pub struct DelayLine {
     samples: Vec<f32>,
@@ -75,19 +75,19 @@ impl Visit for DelayLine {
 }
 
 /// Calculates single coefficient of Hamming window.
-/// https://en.wikipedia.org/wiki/Window_function#Hamming_window
+/// <https://en.wikipedia.org/wiki/Window_function#Hamming_window>
 pub fn hamming_window(i: usize, sample_count: usize) -> f32 {
     0.54 - 0.46 * (2.0 * std::f32::consts::PI * i as f32 / (sample_count - 1) as f32).cos()
 }
 
 /// Calculates single coefficient of Hann window.
-/// https://en.wikipedia.org/wiki/Hann_function
+/// <https://en.wikipedia.org/wiki/Hann_function>
 pub fn hann_window(i: usize, sample_count: usize) -> f32 {
     0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / (sample_count - 1) as f32).cos()
 }
 
 /// Creates new window using specified window function.
-/// https://en.wikipedia.org/wiki/Window_function
+/// <https://en.wikipedia.org/wiki/Window_function>
 pub fn make_window<W: Fn(usize, usize) -> f32>(sample_count: usize, func: W) -> Vec<f32> {
     (0..sample_count).map(|i| func(i, sample_count)).collect()
 }

--- a/rg3d-ui/src/lib.rs
+++ b/rg3d-ui/src/lib.rs
@@ -1,6 +1,6 @@
 //! Extendable, retained mode, graphics API agnostic UI library.
 //!
-//! See examples here - https://github.com/mrDIMAS/rusty-shooter/blob/master/src/menu.rs
+//! See examples here - <https://github.com/mrDIMAS/rusty-shooter/blob/master/src/menu.rs>
 
 #![forbid(unsafe_code)]
 #![allow(irrefutable_let_patterns)]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -27,7 +27,8 @@ use std::time::{self, Duration};
 /// See module docs.
 pub struct Engine<M: MessageData, C: Control<M, C>> {
     context: glutin::WindowedContext<PossiblyCurrent>,
-    /// Current renderer. You should call at least [render] method to see your scene on screen.
+    /// Current renderer. You should call at least [render](Self::render) method to see your scene on
+    /// screen.
     pub renderer: Renderer,
     /// User interface allows you to build interface of any kind. UI itself is *not* thread-safe,
     /// but it uses messages to "talk" with outside world and message queue (MPSC) *is* thread-safe

--- a/src/scene/base.rs
+++ b/src/scene/base.rs
@@ -303,7 +303,7 @@ impl Base {
     }
 
     /// Returns current lifetime of a node. Will be None if node has undefined lifetime.
-    /// For more info about lifetimes see [`set_lifetime`].
+    /// For more info about lifetimes see [`set_lifetime`](Self::set_lifetime).
     pub fn lifetime(&self) -> Option<f32> {
         self.lifetime
     }
@@ -400,7 +400,7 @@ impl Base {
     /// # Details
     ///
     /// This value is used to modify projection matrix before render node.
-    /// Element m[4][3] of projection matrix usually set to -1 to which makes w coordinate
+    /// Element m\[4\]\[3\] of projection matrix usually set to -1 to which makes w coordinate
     /// of in homogeneous space to be -z_fragment for further perspective divide. We can
     /// abuse this to shift z of fragment by some value.
     pub fn set_depth_offset_factor(&mut self, factor: f32) {

--- a/src/scene/transform.rs
+++ b/src/scene/transform.rs
@@ -8,7 +8,7 @@
 //!
 //! rg3d uses complex transform model inherited from FBX transform formulae:
 //!
-//! http://download.autodesk.com/us/fbx/20112/FBX_SDK_HELP/index.html?url=WS1a9193826455f5ff1f92379812724681e696651.htm,topicNumber=d0e7429
+//! <http://download.autodesk.com/us/fbx/20112/FBX_SDK_HELP/index.html?url=WS1a9193826455f5ff1f92379812724681e696651.htm,topicNumber=d0e7429>
 //!
 //! Transform = T * Roff * Rp * Rpre * R * Rpost * Rp⁻¹ * Soff * Sp * S * Sp⁻¹
 //!


### PR DESCRIPTION
Fixes:

1. URLs are now hyper links
2. ```[`method`]``` are now linked with ```[`method`](Self::method)```
3. Add `#![doc(unused)]` in `dummy.rs` (sound module)

I left these warnings in `wav.rs`:

<img width="493" alt="rg3d-warnings" src="https://user-images.githubusercontent.com/47905926/114247069-31570a80-99cf-11eb-9f7f-83049c680b9b.png">

---

Hi mr, awesome work! I'm going to get a credit card :)