### PR TITLE
Initial support for `#[derive(Visit)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/mrDIMAS/rg3d"
 readme = "README.md"
 
 [workspace]
-members = ["rg3d-core", "rg3d-sound", "rg3d-ui", "examples/wasm"]
+members = ["rg3d-core-derive", "rg3d-core", "rg3d-sound", "rg3d-ui", "examples/wasm"]
 
 [profile.dev]
 opt-level = 0

--- a/rg3d-core-derive/Cargo.toml
+++ b/rg3d-core-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rg3d-core-derive"
+version = "0.10.0"
+authors = ["Dmitry Stepanov <d1maxa@yandex.ru>"]
+edition = "2018"
+license = "MIT"
+# description = ""
+repository = "https://github.com/mrDIMAS/rg3d"
+include = ["/src/**/*", "/Cargo.toml", "/README.md"]
+readme = "README.md"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.26"
+quote = "1.0.9"
+syn = "1.0.71"

--- a/rg3d-core-derive/Cargo.toml
+++ b/rg3d-core-derive/Cargo.toml
@@ -13,6 +13,11 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
+convert_case = "0.4.0"
 proc-macro2 = "1.0.26"
 quote = "1.0.9"
 syn = "1.0.71"
+
+[dev-dependencies]
+rg3d = { path = "../" }
+futures = "0.3.14"

--- a/rg3d-core-derive/Cargo.toml
+++ b/rg3d-core-derive/Cargo.toml
@@ -17,6 +17,7 @@ convert_case = "0.4.0"
 proc-macro2 = "1.0.26"
 quote = "1.0.9"
 syn = "1.0.71"
+darling = "0.12.4"
 
 [dev-dependencies]
 rg3d = { path = "../" }

--- a/rg3d-core-derive/Cargo.toml
+++ b/rg3d-core-derive/Cargo.toml
@@ -20,5 +20,5 @@ syn = "1.0.71"
 darling = "0.12.4"
 
 [dev-dependencies]
-rg3d = { path = "../" }
+rg3d-core = { path = "../rg3d-core" }
 futures = "0.3.14"

--- a/rg3d-core-derive/README.md
+++ b/rg3d-core-derive/README.md
@@ -1,0 +1,4 @@
+# rg3d-core-derive
+
+Provides `#[derive(Visitor)]` macro, which implements `rg3d::core::visitor::Visit`.
+

--- a/rg3d-core-derive/src/lib.rs
+++ b/rg3d-core-derive/src/lib.rs
@@ -3,7 +3,8 @@ mod visit;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(Visit)]
+/// Implements `rg3d::core::visitor::Visit`
+#[proc_macro_derive(Visit, attributes(visit))]
 pub fn visit(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     TokenStream::from(visit::impl_visit(ast))

--- a/rg3d-core-derive/src/lib.rs
+++ b/rg3d-core-derive/src/lib.rs
@@ -3,7 +3,9 @@ mod visit;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-/// Implements `rg3d::core::visitor::Visit`
+/// Implements `Visit` trait
+///
+/// User has to import `Visit`, `Visitor` and `VisitResult`.
 #[proc_macro_derive(Visit, attributes(visit))]
 pub fn visit(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/rg3d-core-derive/src/lib.rs
+++ b/rg3d-core-derive/src/lib.rs
@@ -1,0 +1,10 @@
+mod visit;
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(Visit)]
+pub fn visit(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(visit::impl_visit(ast))
+}

--- a/rg3d-core-derive/src/visit.rs
+++ b/rg3d-core-derive/src/visit.rs
@@ -1,0 +1,8 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::*;
+use syn::*;
+
+// implements `Visit` trait
+pub fn impl_visit(ast: DeriveInput) -> TokenStream2 {
+    todo!()
+}

--- a/rg3d-core-derive/src/visit.rs
+++ b/rg3d-core-derive/src/visit.rs
@@ -6,61 +6,317 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::*;
 use syn::*;
 
-// implements `Visit` trait
+// impl `#[derive(Visit)]` for `struct` or `enum`
 pub fn impl_visit(ast: DeriveInput) -> TokenStream2 {
     match ast.data {
         Data::Struct(ref _data) => {
             let struct_args = args::StructArgs::from_derive_input(&ast).unwrap();
             self::impl_visit_struct(struct_args)
         }
-        Data::Enum(ref _data) => todo!("add enum support for #[derive(Visit)]"),
+        Data::Enum(ref data) => self::impl_visit_enum(&ast, data),
         Data::Union(ref _union) => todo!("add union support for #[derive(Visit)]"),
     }
 }
 
-fn impl_visit_struct(args: args::StructArgs) -> TokenStream2 {
-    let field_args = match args.data {
-        ast::Data::Struct(ref field_args) => field_args,
-        ast::Data::Enum(ref _variants) => unreachable!(),
-    };
+fn create_generics<'a>(
+    generics: &Generics,
+    field_args: impl Iterator<Item = &'a args::FieldArgs>,
+) -> Generics {
+    let mut generics = generics.clone();
 
-    // we only accept struct with named fields (for now)
-    assert_eq!(
-        field_args.style,
-        ast::Style::Struct,
-        "add tuple/unit field support for #[derive(Visit)]"
+    // Add where clause for every visited field
+    generics.make_where_clause().predicates.extend(
+        field_args
+            .filter(|f| !f.skip)
+            .map(|f| &f.ty)
+            .map::<WherePredicate, _>(|ty| parse_quote! { #ty: Visit }),
     );
 
-    // `self.field.visit(..);`
-    let field_visits = field_args.fields.iter().filter_map(|field| {
-        if field.skip {
-            return None;
-        }
+    generics
+}
 
-        let field_ident = field.ident.as_ref().unwrap_or_else(|| unreachable!());
-        let field_name = format!("{}", field_ident).to_case(Case::UpperCamel);
-
-        Some(quote! {
-            self.#field_ident.visit(#field_name, visitor)?;
-        })
-    });
-
-    // `impl Visit`
-    let ty_name = &args.ident;
-    let (impl_generics, ty_generics, where_clause) = args.generics.split_for_impl();
+// `impl Visit` for struct
+fn impl_visit_impl<'a>(
+    ty_ident: &Ident,
+    generics: &Generics,
+    field_args: impl Iterator<Item = &'a args::FieldArgs>,
+    visit_body: TokenStream2,
+) -> TokenStream2 {
+    let generics = self::create_generics(generics, field_args);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     quote! {
-        impl #impl_generics rg3d::core::visitor::Visit for #ty_name #ty_generics #where_clause {
+        impl #impl_generics Visit for #ty_ident #ty_generics #where_clause {
+            fn visit(
+                &mut self,
+                #[allow(unused)]
+                name: &str,
+                #[allow(unused)]
+                visitor: &mut Visitor,
+            ) -> VisitResult {
+                #visit_body
+            }
+        }
+    }
+}
+
+/// `<prefix>field.visit("name", visitor);`
+fn create_field_visits<'a>(
+    // None or `f` when bindings tuple variants. NOTE: We can't use `prefix: Ident`
+    prefix: Option<Ident>,
+    fields: impl Iterator<Item = &'a args::FieldArgs>,
+    field_style: ast::Style,
+) -> Vec<TokenStream2> {
+    if field_style == ast::Style::Unit {
+        // `Unit` (struct/enum variant) has no field to visit.
+        // We won't even enter this region:
+        return vec![];
+    }
+
+    fields
+        .filter(|field| !field.skip)
+        .enumerate()
+        .map(|(field_index, field)| {
+            let (ident, name) = match field_style {
+                // `NamedFields { a: f32, .. }`
+                ast::Style::Struct => {
+                    let ident = field.ident.as_ref().unwrap_or_else(|| unreachable!());
+
+                    (
+                        quote!(#ident),
+                        format!("{}", ident).to_case(Case::UpperCamel),
+                    )
+                }
+                // `Tuple(f32, ..)`
+                ast::Style::Tuple => {
+                    let ident = Index::from(field_index);
+
+                    let ident = match prefix {
+                        Some(ref prefix) => {
+                            let ident = format_ident!("{}{}", prefix, ident);
+                            quote!(#ident)
+                        }
+                        None => quote!(#ident),
+                    };
+
+                    (ident, format!("{}", field_index))
+                }
+                ast::Style::Unit => unreachable!(),
+            };
+
+            quote! {
+                #ident.visit(#name, visitor)?;
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+/// impl `Visit` for `struct`
+fn impl_visit_struct(args: args::StructArgs) -> TokenStream2 {
+    let field_args = args.data.take_struct().unwrap_or_else(|| unreachable!());
+
+    self::impl_visit_impl(
+        // impl block parameters:
+        &args.ident,
+        &args.generics,
+        field_args.iter(),
+        // visit function body:
+        if field_args.style.clone() == ast::Style::Unit {
+            quote! { Ok(()) }
+        } else {
+            // `field.visit(..);` parts
+            let field_visits =
+                self::create_field_visits(None, field_args.fields.iter(), field_args.style);
+
+            quote! {
+                visitor.enter_region(name)?;
+                #(self.#field_visits)*
+                visitor.leave_region()
+            }
+        },
+    )
+}
+
+/// impl `Visit` for `enum`
+fn impl_visit_enum(ast: &DeriveInput, data: &DataEnum) -> TokenStream2 {
+    let ty_ident = &ast.ident;
+    let ty_name = format!("{}", ty_ident);
+
+    // variant ID = variant index
+    let id_type = quote!(u32);
+
+    // `fn id(&self) -> u32`
+    let fn_id = {
+        let matchers = data
+            .variants
+            .iter()
+            .enumerate()
+            .map(|(variant_index, variant)| {
+                let variant_index = variant_index as u32;
+                let variant_ident = &variant.ident;
+
+                match variant.fields {
+                    Fields::Named(_) => quote! {
+                        #ty_ident::#variant_ident { .. } => #variant_index,
+                    },
+                    Fields::Unnamed(_) => {
+                        let idents = (0..variant.fields.len()).map(|__| quote!(_));
+
+                        quote! {
+                            #ty_ident::#variant_ident(#(#idents),*) => #variant_index,
+                        }
+                    }
+                    Fields::Unit => quote! {
+                        #ty_ident::#variant_ident => #variant_index,
+                    },
+                }
+            });
+
+        quote! {
+            fn id(me: &#ty_ident) -> #id_type {
+                match me {
+                    #(#matchers)*
+                    _ => unreachable!("Unable to get ID from enum variant") ,
+                }
+            }
+        }
+    };
+
+    // `fn from_id(id: u32) -> Result<Self, String>`
+    let fn_from_id = {
+        // `<variant_index> => Ok(TypeName::Variant(Default::default())),
+        let matchers = data
+            .variants
+            .iter()
+            .enumerate()
+            .map(|(variant_index, variant)| {
+                let variant_index = variant_index as u32;
+                let variant_ident = &variant.ident;
+
+                // create default value of this variant
+                let default = match &variant.fields {
+                    Fields::Named(fields) => {
+                        let defaults = fields.named.iter().map(|field| {
+                            let field_ident = &field.ident;
+                            quote! {
+                                #field_ident: Default::default(),
+                            }
+                        });
+
+                        quote! {
+                            #ty_ident::#variant_ident {
+                                #(#defaults)*
+                            },
+                        }
+                    }
+                    Fields::Unnamed(fields) => {
+                        let defaults = fields
+                            .unnamed
+                            .iter()
+                            .map(|_| quote! { Default::default(), });
+
+                        quote! {
+                            #ty_ident::#variant_ident(#(#defaults)*),
+                        }
+                    }
+                    Fields::Unit => quote! {
+                        #ty_ident::#variant_ident
+                    },
+                };
+
+                quote! {
+                    id if id == #variant_index => Ok(#default),
+                }
+            });
+
+        quote! {
+            fn from_id(id: #id_type) -> std::result::Result<#ty_ident, String> {
+                match id {
+                    #(#matchers)*
+                    _ => Err(format!("Unknown ID for type `{}`: `{}`", #ty_name, id)),
+                }
+            }
+        }
+    };
+
+    // visit every field of each variant
+    let variant_visits = data.variants.iter().map(|variant| {
+        let (fields, style): (Vec<_>, _) = match &variant.fields {
+            Fields::Named(fields) => (fields.named.iter().collect(), ast::Style::Struct),
+            Fields::Unnamed(fields) => (fields.unnamed.iter().collect(), ast::Style::Tuple),
+            Fields::Unit => (vec![], ast::Style::Unit),
+        };
+
+        let fields = fields
+            .iter()
+            .map(|f| args::FieldArgs::from_field(f).unwrap())
+            .collect::<Vec<_>>();
+
+        let variant_ident = &variant.ident;
+
+        match style {
+            ast::Style::Struct => {
+                let field_visits = self::create_field_visits(None, fields.iter(), style);
+
+                let idents = fields.iter().map(|field| {
+                    let ident = &field.ident;
+                    quote!(#ident)
+                });
+
+                quote! {
+                    #ty_ident::#variant_ident { #(#idents),* } => {
+                        #(#field_visits)*
+                    },
+                }
+            }
+            ast::Style::Tuple => {
+                let field_visits = self::create_field_visits(parse_quote!(f), fields.iter(), style);
+
+                let idents = (0..fields.len()).map(|i| format_ident!("f{}", Index::from(i)));
+
+                quote! {
+                    #ty_ident::#variant_ident(#(#idents),*) => {
+                        #(#field_visits)*
+                    },
+                }
+            }
+            ast::Style::Unit => quote! {
+                #ty_ident::#variant_ident => {},
+            },
+        }
+    });
+
+    // self::impl_visit_impl(ty_ident, &ast.generics,
+
+    // TODO: add generic bounds
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    // plain-enum-only support
+    quote! {
+        impl #impl_generics Visit for #ty_ident #ty_generics #where_clause {
             fn visit(
                 &mut self,
                 name: &str,
-                visitor: &mut rg3d::core::visitor::Visitor,
-            ) -> rg3d::core::visitor::VisitResult {
+                visitor: &mut Visitor,
+            ) -> VisitResult {
                 visitor.enter_region(name)?;
 
-                #(#field_visits)*
+                let mut id = id(self);
+                id.visit("Id", visitor)?;
 
-                visitor.leave_region()
+                if visitor.is_reading() {
+                    *self = from_id(id)?;
+                }
+
+                match self {
+                    #(#variant_visits)*
+                }
+
+                return visitor.leave_region();
+
+                #fn_id
+
+                #fn_from_id
             }
         }
     }

--- a/rg3d-core-derive/src/visit.rs
+++ b/rg3d-core-derive/src/visit.rs
@@ -1,8 +1,47 @@
+use convert_case::{Case, Casing};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::*;
 use syn::*;
 
 // implements `Visit` trait
 pub fn impl_visit(ast: DeriveInput) -> TokenStream2 {
-    todo!()
+    match ast.data {
+        Data::Struct(ref data) => self::impl_visit_struct(&ast, data),
+        Data::Enum(ref _data) => todo!("add enum support for #[derive(Visit)]"),
+        Data::Union(ref _union) => todo!("add union support for #[derive(Visit)]"),
+    }
+}
+
+fn impl_visit_struct(ast: &DeriveInput, data: &DataStruct) -> TokenStream2 {
+    let fields = match data.fields {
+        Fields::Named(ref fields) => fields,
+        Fields::Unnamed(ref _fields) => todo!("support unnamed fields"),
+        Fields::Unit => todo!("support unit struct"),
+    };
+
+    // `self.field.visit(..);`
+    let field_visits = fields.named.iter().map(|field| {
+        let field_ident = field.ident.as_ref().unwrap_or_else(|| unreachable!());
+        let field_name = format!("{}", field_ident).to_case(Case::UpperCamel);
+
+        quote! {
+            self.#field_ident.visit(#field_name, visitor)?;
+        }
+    });
+
+    // `impl Visit`
+    let ty_name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics rg3d::core::visitor::Visit for #ty_name #ty_generics #where_clause {
+            fn visit(&mut self, name: &str, visitor: &mut rg3d::core::visitor::Visitor) -> VisitResult {
+                visitor.enter_region(name)?;
+
+                #(#field_visits)*
+
+                visitor.leave_region()
+            }
+        }
+    }
 }

--- a/rg3d-core-derive/src/visit/args.rs
+++ b/rg3d-core-derive/src/visit/args.rs
@@ -1,0 +1,20 @@
+use darling::*;
+use syn::*;
+
+#[derive(FromDeriveInput)]
+#[darling(supports(struct_any))]
+pub struct StructArgs {
+    pub ident: Ident,
+    // pub vis: Visibility,
+    pub generics: Generics,
+    pub data: ast::Data<(), FieldArgs>,
+    // attrs: Vec<Attribute>
+}
+
+#[derive(FromField)]
+pub struct FieldArgs {
+    pub ident: Option<Ident>,
+    // pub vis: Visibility,
+    pub ty: Type,
+    // pub attrs: Vec<Attribute>,
+}

--- a/rg3d-core-derive/src/visit/args.rs
+++ b/rg3d-core-derive/src/visit/args.rs
@@ -11,6 +11,7 @@ pub struct StructArgs {
     // attrs: Vec<Attribute>
 }
 
+/// Parsed from struct's or enum variant's field
 #[derive(FromField)]
 #[darling(attributes(visit))]
 pub struct FieldArgs {

--- a/rg3d-core-derive/src/visit/args.rs
+++ b/rg3d-core-derive/src/visit/args.rs
@@ -12,7 +12,7 @@ pub struct StructArgs {
 }
 
 /// Parsed from struct's or enum variant's field
-#[derive(FromField)]
+#[derive(FromField, Clone)]
 #[darling(attributes(visit))]
 pub struct FieldArgs {
     pub ident: Option<Ident>,
@@ -23,4 +23,20 @@ pub struct FieldArgs {
     /// `#[visit(skip)]`: skip on read and write
     #[darling(default)]
     pub skip: bool,
+}
+
+/// Collect [`FieldArgs`] manually from [`syn::Variant`]
+pub fn field_args_from_variant(variant: &Variant) -> (Vec<FieldArgs>, ast::Style) {
+    let (fields, style): (Vec<_>, _) = match &variant.fields {
+        Fields::Named(fields) => (fields.named.iter().collect(), ast::Style::Struct),
+        Fields::Unnamed(fields) => (fields.unnamed.iter().collect(), ast::Style::Tuple),
+        Fields::Unit => (vec![], ast::Style::Unit),
+    };
+
+    let fields = fields
+        .iter()
+        .map(|f| self::FieldArgs::from_field(f).unwrap())
+        .collect::<Vec<_>>();
+
+    (fields, style)
 }

--- a/rg3d-core-derive/src/visit/args.rs
+++ b/rg3d-core-derive/src/visit/args.rs
@@ -2,19 +2,24 @@ use darling::*;
 use syn::*;
 
 #[derive(FromDeriveInput)]
-#[darling(supports(struct_any))]
+#[darling(attributes(visit), supports(struct_any))]
 pub struct StructArgs {
     pub ident: Ident,
     // pub vis: Visibility,
     pub generics: Generics,
-    pub data: ast::Data<(), FieldArgs>,
+    pub data: ast::Data<util::Ignored, FieldArgs>,
     // attrs: Vec<Attribute>
 }
 
 #[derive(FromField)]
+#[darling(attributes(visit))]
 pub struct FieldArgs {
     pub ident: Option<Ident>,
     // pub vis: Visibility,
     pub ty: Type,
     // pub attrs: Vec<Attribute>,
+    // ---
+    /// `#[visit(skip)]`: skip on read and write
+    #[darling(default)]
+    pub skip: bool,
 }

--- a/rg3d-core-derive/tests/basic.rs
+++ b/rg3d-core-derive/tests/basic.rs
@@ -1,12 +1,19 @@
 use std::{env, fs::File, io::Write, path::PathBuf};
 
 use futures::executor::block_on;
-use rg3d::core::visitor::{Visit, VisitResult, Visitor};
+use rg3d::core::visitor::{Visit, Visitor};
 
 #[derive(Debug, Clone, Default, PartialEq, Visit)]
 struct NamedFields {
     a: f32,
     snake_case: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Visit)]
+struct SkipAttr {
+    visited: f32,
+    #[visit(skip)]
+    skipped: u32,
 }
 
 #[test]
@@ -38,5 +45,43 @@ fn named_fields() {
         loaded_data.visit("Data", &mut visitor).unwrap();
 
         assert_eq!(data, loaded_data);
+    }
+}
+
+#[test]
+fn skip_attr() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let root = PathBuf::from(manifest_dir).join("test_output");
+
+    let mut data = SkipAttr {
+        visited: 10.0,
+        skipped: 20,
+    };
+    let bin = root.join("skip_attr.bin");
+    let txt = root.join("skip_attr.txt");
+
+    // Save
+    {
+        let mut visitor = Visitor::new();
+        data.visit("Data", &mut visitor).unwrap();
+
+        visitor.save_binary(&bin).unwrap();
+        let mut file = File::create(&txt).unwrap();
+        file.write(visitor.save_text().as_bytes()).unwrap();
+    }
+
+    // Load
+    {
+        let mut visitor = block_on(Visitor::load_binary(&bin)).unwrap();
+        let mut loaded_data = SkipAttr::default();
+        loaded_data.visit("Data", &mut visitor).unwrap();
+
+        assert_eq!(
+            loaded_data,
+            SkipAttr {
+                visited: data.visited,
+                skipped: Default::default(),
+            }
+        );
     }
 }

--- a/rg3d-core-derive/tests/basic.rs
+++ b/rg3d-core-derive/tests/basic.rs
@@ -56,6 +56,15 @@ enum ComplexEnum {
     NamedFields { a: f32, b: u32 },
 }
 
+#[derive(Debug, Clone, PartialEq, Visit)]
+enum GenericEnum<T>
+where
+    T: std::fmt::Debug,
+{
+    UnitVariant,
+    Tuple(i32, Vec<T>),
+}
+
 /// Saves given `data` and overwrites `data_default` with the saved data.
 /// Test the equality after running this method!
 fn save_load<T: Visit>(test_name: &str, data: &mut T, data_default: &mut T) {
@@ -201,6 +210,26 @@ fn complex_enum() {
     let mut data_default = ComplexEnum::UnitVariant;
 
     self::save_load("complex_enum", &mut data, &mut data_default);
+
+    assert_eq!(data, data_default);
+}
+
+#[test]
+fn generic_enum() {
+    #[derive(Debug)]
+    struct NotVisit;
+
+    #[allow(warnings)]
+    let mut not_compile = GenericEnum::Tuple(1, vec![NotVisit]);
+
+    // Compile error because `Generics<NotVisit> is not `Visit`:
+    // let mut visitor = Visitor::new();
+    // not_compile.visit("Data", &mut visitor).unwrap();
+
+    let mut data = GenericEnum::Tuple(1, vec![100u32]);
+    let mut data_default = GenericEnum::UnitVariant;
+
+    self::save_load("generic_enum", &mut data, &mut data_default);
 
     assert_eq!(data, data_default);
 }

--- a/rg3d-core-derive/tests/basic.rs
+++ b/rg3d-core-derive/tests/basic.rs
@@ -1,7 +1,7 @@
 use std::{env, fs::File, io::Write, path::PathBuf};
 
 use futures::executor::block_on;
-use rg3d_core::visitor::{Visit, VisitError, VisitResult, Visitor};
+use rg3d_core::visitor::prelude::*;
 
 #[derive(Debug, Clone, Default, PartialEq, Visit)]
 struct NamedFields {

--- a/rg3d-core-derive/tests/basic.rs
+++ b/rg3d-core-derive/tests/basic.rs
@@ -1,7 +1,7 @@
 use std::{env, fs::File, io::Write, path::PathBuf};
 
 use futures::executor::block_on;
-use rg3d::core::visitor::{Visit, Visitor};
+use rg3d_core::visitor::{Visit, VisitError, VisitResult, Visitor};
 
 #[derive(Debug, Clone, Default, PartialEq, Visit)]
 struct NamedFields {
@@ -10,78 +10,197 @@ struct NamedFields {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Visit)]
+struct UnitStruct;
+
+#[derive(Debug, Clone, Default, PartialEq, Visit)]
+struct TupleStruct(f32, u32);
+
+#[derive(Debug, Clone, Default, PartialEq, Visit)]
 struct SkipAttr {
     visited: f32,
     #[visit(skip)]
     skipped: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Visit)]
+struct Generics<T> {
+    items: Vec<T>,
+}
+
+// NOTE: This enum doesn't implement copy, but `#[derive(Visit)]` still works
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Visit)]
+enum PlainEnum {
+    A,
+    B,
+    C,
+}
+
+// NOTE: implementing default for `PlainEnum` is REQUIRED to derive `Visit` for `OnefTheTypes`
+impl Default for PlainEnum {
+    fn default() -> Self {
+        Self::A
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Visit)]
+enum OneOfTheTypes {
+    NamedFields(NamedFields),
+    PlainEnum(PlainEnum),
+    U32(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Visit)]
+enum ComplexEnum {
+    UnitVariant,
+    Tuple(i32, i32),
+    NamedFields { a: f32, b: u32 },
+}
+
+/// Saves given `data` and overwrites `data_default` with the saved data.
+/// Test the equality after running this method!
+fn save_load<T: Visit>(test_name: &str, data: &mut T, data_default: &mut T) {
+    // Locate output path
+    let (bin, txt) = {
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+        let root = PathBuf::from(manifest_dir).join("test_output");
+        (
+            root.join(format!("{}.bin", test_name)),
+            root.join(format!("{}.txt", test_name)),
+        )
+    };
+
+    // Save `data`
+    {
+        let mut visitor = Visitor::new();
+        data.visit("Data", &mut visitor).unwrap();
+
+        visitor.save_binary(&bin).unwrap();
+        let mut file = File::create(&txt).unwrap();
+        file.write(visitor.save_text().as_bytes()).unwrap();
+    }
+
+    // Load the saevd data to `data_default`
+    {
+        let mut visitor = block_on(Visitor::load_binary(&bin)).unwrap();
+        // overwrite the default data with saved data
+        data_default.visit("Data", &mut visitor).unwrap();
+    }
+
+    // Test function would would do:
+    // assert_eq!(data, default_data);
+}
+
 #[test]
 fn named_fields() {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let root = PathBuf::from(manifest_dir).join("test_output");
-
     let mut data = NamedFields {
         a: 100.0,
         snake_case: 200,
     };
-    let bin = root.join("named_fields.bin");
-    let txt = root.join("named_fields.txt");
+    let mut data_default = NamedFields::default();
 
-    // Save
-    {
-        let mut visitor = Visitor::new();
-        data.visit("Data", &mut visitor).unwrap();
+    self::save_load("named_fields", &mut data, &mut data_default);
 
-        visitor.save_binary(&bin).unwrap();
-        let mut file = File::create(&txt).unwrap();
-        file.write(visitor.save_text().as_bytes()).unwrap();
-    }
+    // The default data was overwritten with saved data.
+    // Now it should be same as the original data:
+    assert_eq!(data, data_default);
+}
 
-    // Load
-    {
-        let mut visitor = block_on(Visitor::load_binary(&bin)).unwrap();
-        let mut loaded_data = NamedFields::default();
-        loaded_data.visit("Data", &mut visitor).unwrap();
+#[test]
+fn unit_struct() {
+    let mut data = UnitStruct;
+    let mut data_default = UnitStruct;
 
-        assert_eq!(data, loaded_data);
-    }
+    // non seuse.. but anyways,
+    // `Visit` is implemented `UnitStruct;` as empty code block `{}`
+    self::save_load("unit_struct", &mut data, &mut data_default);
+
+    assert_eq!(data, data_default);
+}
+
+#[test]
+fn tuple_struct() {
+    let mut data = TupleStruct(10.0, 20);
+    let mut data_default = TupleStruct(0.0, 0);
+
+    self::save_load("tuple_struct", &mut data, &mut data_default);
+
+    assert_eq!(data, data_default);
 }
 
 #[test]
 fn skip_attr() {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let root = PathBuf::from(manifest_dir).join("test_output");
-
     let mut data = SkipAttr {
         visited: 10.0,
         skipped: 20,
     };
-    let bin = root.join("skip_attr.bin");
-    let txt = root.join("skip_attr.txt");
+    let mut data_default = SkipAttr::default();
 
-    // Save
-    {
-        let mut visitor = Visitor::new();
-        data.visit("Data", &mut visitor).unwrap();
+    self::save_load("skip_attr", &mut data, &mut data_default);
 
-        visitor.save_binary(&bin).unwrap();
-        let mut file = File::create(&txt).unwrap();
-        file.write(visitor.save_text().as_bytes()).unwrap();
-    }
+    // The default data was overwritten with saved data,
+    // except the `skipped` field:
+    assert_eq!(
+        data_default,
+        SkipAttr {
+            visited: data.visited,
+            skipped: Default::default(),
+        }
+    );
+}
 
-    // Load
-    {
-        let mut visitor = block_on(Visitor::load_binary(&bin)).unwrap();
-        let mut loaded_data = SkipAttr::default();
-        loaded_data.visit("Data", &mut visitor).unwrap();
+#[test]
+fn generics() {
+    struct NotVisit;
 
-        assert_eq!(
-            loaded_data,
-            SkipAttr {
-                visited: data.visited,
-                skipped: Default::default(),
-            }
-        );
-    }
+    #[allow(warnings)]
+    let mut not_compile = Generics {
+        items: vec![NotVisit],
+    };
+
+    // Compile error because `Generics<NotVisit> is not `Visit`:
+    // let mut visitor = Visitor::new();
+    // not_compile.visit("Data", &mut visitor).unwrap();
+
+    // But `Generics<T: Visit` is `Visit`
+    let mut data = Generics {
+        items: vec![100u32],
+    };
+    let mut data_default = Generics { items: vec![] };
+
+    self::save_load("generics", &mut data, &mut data_default);
+
+    assert_eq!(data, data_default);
+}
+
+#[test]
+fn plain_enum() {
+    let mut data = PlainEnum::C;
+    let mut data_default = PlainEnum::A;
+
+    self::save_load("plain_enum", &mut data, &mut data_default);
+
+    assert_eq!(data, data_default);
+}
+
+#[test]
+fn one_of_the_types() {
+    let mut data = OneOfTheTypes::NamedFields(NamedFields {
+        a: 1.0,
+        snake_case: 10,
+    });
+    let mut data_default = OneOfTheTypes::U32(0);
+
+    self::save_load("one_of_the_types", &mut data, &mut data_default);
+
+    assert_eq!(data, data_default);
+}
+
+#[test]
+fn complex_enum() {
+    let mut data = ComplexEnum::Tuple(100, 200);
+    let mut data_default = ComplexEnum::UnitVariant;
+
+    self::save_load("complex_enum", &mut data, &mut data_default);
+
+    assert_eq!(data, data_default);
 }

--- a/rg3d-core-derive/tests/basic.rs
+++ b/rg3d-core-derive/tests/basic.rs
@@ -1,0 +1,42 @@
+use std::{env, fs::File, io::Write, path::PathBuf};
+
+use futures::executor::block_on;
+use rg3d::core::visitor::{Visit, VisitResult, Visitor};
+
+#[derive(Debug, Clone, Default, PartialEq, Visit)]
+struct NamedFields {
+    a: f32,
+    snake_case: u32,
+}
+
+#[test]
+fn named_fields() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let root = PathBuf::from(manifest_dir).join("test_output");
+
+    let mut data = NamedFields {
+        a: 100.0,
+        snake_case: 200,
+    };
+    let bin = root.join("named_fields.bin");
+    let txt = root.join("named_fields.txt");
+
+    // Save
+    {
+        let mut visitor = Visitor::new();
+        data.visit("Data", &mut visitor).unwrap();
+
+        visitor.save_binary(&bin).unwrap();
+        let mut file = File::create(&txt).unwrap();
+        file.write(visitor.save_text().as_bytes()).unwrap();
+    }
+
+    // Load
+    {
+        let mut visitor = block_on(Visitor::load_binary(&bin)).unwrap();
+        let mut loaded_data = NamedFields::default();
+        loaded_data.visit("Data", &mut visitor).unwrap();
+
+        assert_eq!(data, loaded_data);
+    }
+}

--- a/rg3d-core/Cargo.toml
+++ b/rg3d-core/Cargo.toml
@@ -10,6 +10,8 @@ include = ["/src/**/*", "/Cargo.toml", "/LICENSE", "/README.md"]
 readme = "README.md"
 
 [dependencies]
+rg3d-core-derive = { path = "../rg3d-core-derive", version = "0.10.0" }
+
 base64 = "0.13.0"
 byteorder = "1.4.2"
 rand = "0.8.3"

--- a/rg3d-core/src/visitor.rs
+++ b/rg3d-core/src/visitor.rs
@@ -8,7 +8,10 @@
 //! types and some of basic structures of the crate. Main criteria of what could be the field and what
 //! not is the ability to be represented as set of bytes without any aliasing issues.
 
+pub use rg3d_core_derive::Visit;
+
 use crate::io::FileLoadError;
+
 use crate::{
     algebra::{Matrix3, Matrix4, Quaternion, UnitQuaternion, Vector2, Vector3, Vector4},
     io,

--- a/rg3d-core/src/visitor.rs
+++ b/rg3d-core/src/visitor.rs
@@ -10,6 +10,11 @@
 
 pub use rg3d_core_derive::Visit;
 
+pub mod prelude {
+    //! Types to use `#[derive(Visit)]`
+    pub use super::{Visit, VisitResult, Visitor};
+}
+
 use crate::io::FileLoadError;
 
 use crate::{


### PR DESCRIPTION
# About

This PR adds experimentals supports for `#[derive(Visit)]`

## How to use

```rust
use rg3d::core::visitor::prelude::*;
// or: use rg3d_core::visitor::prelude::*;

#[derive(Visit)]
pub struct MyCoolStruct { .. }
```

## Supported types

* `struct UnitStruct;`
* `struct TupleFields(f32, f32);`
* `struct NamedFields { a: f32, b: f32 }`
* `enum ComplexEnum { UnitVariant, TupleVariant(f32, 32), NamedVariant { a: f32,  b: f32 } }`

Generics are also considered. For example, `struct Generics<T> { items: Vec<T> }` implements `Visit` with `where Vec<T>: Visit` clause.

## Note

Please run `cargo expand --tests basic` to know what the `Visit` implementations are like :)

# Old WIP comments

<details>
  <summary>Old comments</summary>

## Progress

* [x] Struct with named fields

<details>
  <summary>Example</summary>

```rust
// imports both the trait and the derive macro
use rg3d::core::visitor::Visit;

#[derive(Visit)]
struct NamedFields {
    a: f32,
    snake_case: u32,
}
```

Part of `cargo expand --test basic`:

```rust
impl rg3d::core::visitor::Visit for NamedFields {
    fn visit(
        &mut self,
        name: &str,
        visitor: &mut rg3d::core::visitor::Visitor,
    ) -> rg3d::core::visitor::VisitResult {
        visitor.enter_region(name)?;
        self.a.visit("A", visitor)?;
        self.snake_case.visit("SnakeCase", visitor)?;
        visitor.leave_region()
    }
}
```

</details>

* [x] Implemeint `#[visit(skip)]` field attribute (using [darling](https://github.com/TedDriggs/darling))

<details>
  <summary>Example</summary>

```rust
use rg3d::core::visitor::Visit;

#[derive(Debug, Clone, Default, PartialEq, Visit)]
struct SkipAttr {
    visited: f32,
    #[visit(skip)]
    skipped: u32,
}
```

Part of `cargo expand --test basic`:

```rust
impl rg3d::core::visitor::Visit for SkipAttr {
    fn visit(
        &mut self,
        name: &str,
        visitor: &mut rg3d::core::visitor::Visitor,
    ) -> rg3d::core::visitor::VisitResult {
        visitor.enter_region(name)?;
        self.visited.visit("Visited", visitor)?;
        visitor.leave_region()
    }
}
```

</details>
 
* [x] Support plain enums

<details>
  <summary>Example</summary>

```rust
#[derive(Debug, Clone, PartialEq, Eq, Hash, Visit)]
enum PlainEnum {
    A,
    B,
    C,
}
```

Part of `cargo expand --test basic`:

```rust
impl rg3d::core::visitor::Visit for PlainEnum {
    fn visit(
        &mut self,
        name: &str,
        visitor: &mut rg3d::core::visitor::Visitor,
    ) -> rg3d::core::visitor::VisitResult {
        visitor.enter_region(name)?;
        let mut id = self.clone() as u32;
        id.visit("Id", visitor)?;
        if visitor.is_reading() {
            *self = match id {
                id if id == PlainEnum::A as u32 => PlainEnum::A,
                id if id == PlainEnum::B as u32 => PlainEnum::B,
                id if id == PlainEnum::C as u32 => PlainEnum::C,
                _ => {
                    return Err(rg3d::core::visitor::VisitError::User({
                        let res = ::alloc::fmt::format(::core::fmt::Arguments::new_v1(
                            &["Invalid ID for enum `", "`: "],
                            &match (&"PlainEnum", &id) {
                                (arg0, arg1) => [
                                    ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Display::fmt),
                                    ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
                                ],
                            },
                        ));
                        res
                    }))
                }
            }
        }
        visitor.leave_region()
    }
}
```

</details>

* [x] Support one-of-the-types enums (upcasting enums)

<details>
  <summary>Example</summary>

```rust
#[derive(Debug, Clone, PartialEq, Visit)]
enum OneOfTheTypes {
    NamedFields(NamedFields),
    PlainEnum(PlainEnum),
    U32(u32),
}
```

Part of `cargo expand --test basic`:

```rust
impl rg3d::core::visitor::Visit for OneOfTheTypes {
    fn visit(
        &mut self,
        name: &str,
        visitor: &mut rg3d::core::visitor::Visitor,
    ) -> rg3d::core::visitor::VisitResult {
        fn id(me: &OneOfTheTypes) -> u32 {
            match me {
                OneOfTheTypes::NamedFields(_) => 0u32,
                OneOfTheTypes::PlainEnum(_) => 1u32,
                OneOfTheTypes::U32(_) => 2u32,
                _ => ::core::panicking::panic_fmt(::core::fmt::Arguments::new_v1(
                    &["internal error: entered unreachable code: "],
                    &match (&"Unable to get ID from enum variant",) {
                        (arg0,) => [::core::fmt::ArgumentV1::new(
                            arg0,
                            ::core::fmt::Display::fmt,
                        )],
                    },
                )),
            }
        }
        fn from_id(id: u32) -> std::result::Result<OneOfTheTypes, String> {
            match id {
                id if id == 0u32 => Ok(OneOfTheTypes::NamedFields(Default::default())),
                id if id == 1u32 => Ok(OneOfTheTypes::PlainEnum(Default::default())),
                id if id == 2u32 => Ok(OneOfTheTypes::U32(Default::default())),
                _ => Err({
                    let res = ::alloc::fmt::format(::core::fmt::Arguments::new_v1(
                        &["Unknown ID for type `", "`: `", "`"],
                        &match (&"OneOfTheTypes", &id) {
                            (arg0, arg1) => [
                                ::core::fmt::ArgumentV1::new(arg0, ::core::fmt::Display::fmt),
                                ::core::fmt::ArgumentV1::new(arg1, ::core::fmt::Display::fmt),
                            ],
                        },
                    ));
                    res
                }),
            }
        }
        visitor.enter_region(name)?;
        let mut id = id(self);
        id.visit("KindId", visitor)?;
        if visitor.is_reading() {
            *self = from_id(id)?;
        }
        match self {
            OneOfTheTypes::NamedFields(v) => v.visit("Data", visitor)?,
            OneOfTheTypes::PlainEnum(v) => v.visit("Data", visitor)?,
            OneOfTheTypes::U32(v) => v.visit("Data", visitor)?,
        }
        visitor.leave_region()
    }
}
```

</details>

## TODOs

* [ ] Polish
As in the first comment in this PR, we can support more types and make the implementation simpler.

* [ ] `#[visit(rename = ..)]` attribute
* [ ] Attribute macros on enum variant fields1

## Problems

* The `Visit` macro is exposed in `rg3d-core::visitor`, but it requires `rg3d` to be in scope of user (since it implements `rg3d::core::visitor::Visit`). If anyone uses `rg3d-core` as a stand-alone crate, it doesn't make sense.

* Replacing existing `Visit` implementation with the derive macro may break the byte data compatibility (if I understand correctly).
  * `#[derive(Visit)]` calls struct fields in the order of field declarations.
  * Each data may be given different name between before/after using `#[derive(Visit)]`.

## Implementation problems

* I'm using `syn` types for enums because I couldn't figure out how to use `darling` for enums.

</details>